### PR TITLE
Fixed curse words and punctuation

### DIFF
--- a/javascripts/curse.js
+++ b/javascripts/curse.js
@@ -11,43 +11,33 @@ var Chatty = (function(oldChatty) {
   aiXML.send();
   //End XHR
 
-  //Checks the message array for curses
   oldChatty.checkCurse = function() {
-    var messageChecker = Chatty.getMessages()
-    var newMessages = []
-    //Runs through message array takes into strings and breaks each into an array and then finally checks each agains the curse words. If it finds any, it adds styling.After puts them all back together and stores it back into the message array.
+    var messageChecker = Chatty.getMessages();
+    //Runs through message array takes into strings checks each agains the curse words. If it finds any, it adds styling.
+    //After puts them back into the message array.
     for (var i in messageChecker) {
-      let tempVar = messageChecker[i].message.split(" ")
-      for (var j in tempVar) {
-        for (var k in curses) {
-          if (tempVar[j].toLowerCase() === curses[k]) {
-            tempVar[j] = `<span class='curse'>${curses[k].toUpperCase()}</span>`
-            tempVar[j]
-          }
-        }
-      }
-      messageChecker[i].message = tempVar.join(" ")
+      let tempMessage = messageChecker[i].message;
+      for (var k in curses) {
+        let regWithCurse = new RegExp ("\\b" + curses[k] + "\\b", "ig");
+        if (tempMessage.search(regWithCurse) != -1) {
+          tempMessage = tempMessage.replace(regWithCurse, `<span class='curse'>${curses[k].toUpperCase()}</span>`);
+        };
+      };
+      messageChecker[i].message = tempMessage;
     };
-    Chatty.replaceMessages(messageChecker)
+    Chatty.replaceMessages(messageChecker);
   }
 
   //Reverses the previous process, but only for 1 message. Takes Styling out of the string.
-    oldChatty.revertCurse = function(msgText, msgID) {
-    msgID = document.getElementById(msgID)
-    let span = msgID.getElementsByTagName('span')
-    var newMessages = []
-    let tempVar = msgText.split(" ")
-    let j = 1
-    for (var i in tempVar) {
-      if (tempVar[i] === "<span") {
-        tempVar.splice(i,1)
-      }
-      if (tempVar[i].indexOf("</span>") > -1) {
-        tempVar[i] = span[j].innerHTML
-        j++
-      }
-    }
-    return tempVar.join(" ")
+  oldChatty.revertCurse = function(msgText, msgID) {
+  msgID = document.getElementById(msgID)
+  let spanOpen = new RegExp (/\<span class="curse"\>/, "ig");
+  let spanClose = new RegExp (/\<\/span\>/, "ig");
+
+  msgText = msgText.replace(spanOpen, "");
+  msgText = msgText.replace(spanClose, "");
+
+  return msgText;
   }
 
   return Chatty


### PR DESCRIPTION
The curse words could be missed if wrapped in punctuation. Converted the checks to RegEx for both the checking and reverting of the curse words strings.
